### PR TITLE
Link member fee rows and fix Facebook URL

### DIFF
--- a/src/app/[locale]/conference2026/page.tsx
+++ b/src/app/[locale]/conference2026/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Mail, CalendarDays, FileText, Users } from "lucide-react";
 import { getMarkdownContent } from "@/lib/markdown";
 import { FadeIn, FadeInView } from "@/components/ui/motion";
@@ -572,7 +573,15 @@ export default async function Conference2026Page({ params }: PageProps) {
                         <td className="py-3 text-black/40">€80</td>
                       </tr>
                       <tr>
-                        <td className="py-3 pr-4">HGS Members <span className="text-xs text-black/40">(in good standing)</span></td>
+                        <td className="py-3 pr-4">
+                          <Link
+                            href={`/${validLocale}/society/registration`}
+                            className="font-medium text-black underline underline-offset-4 decoration-black/20 hover:decoration-black transition-colors"
+                          >
+                            HGS Members
+                          </Link>{" "}
+                          <span className="text-xs text-black/40">(in good standing)</span>
+                        </td>
                         <td className="py-3 pr-4 font-medium">€40</td>
                         <td className="py-3 text-black/40">€50</td>
                       </tr>
@@ -582,7 +591,14 @@ export default async function Conference2026Page({ params }: PageProps) {
                         <td className="py-3 text-black/40">€30</td>
                       </tr>
                       <tr>
-                        <td className="py-3 pr-4">HGS Student Members</td>
+                        <td className="py-3 pr-4">
+                          <Link
+                            href={`/${validLocale}/society/registration`}
+                            className="font-medium text-black underline underline-offset-4 decoration-black/20 hover:decoration-black transition-colors"
+                          >
+                            HGS Student Members
+                          </Link>
+                        </td>
                         <td className="py-3 pr-4 font-medium">€10</td>
                         <td className="py-3 text-black/40">€15</td>
                       </tr>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -19,7 +19,7 @@ export const siteConfig = {
   },
   mapUrl: "https://maps.app.goo.gl/g7kBUna8MDYhGkAF7",
   social: {
-    facebook: "https://www.facebook.com/profile.php?id=61558192471144",
+    facebook: "https://www.facebook.com/HellenicGEOSOCIETY",
     linkedin: "https://www.linkedin.com/company/hellenic-geographical-society",
   },
   banking: {


### PR DESCRIPTION
## Summary
- Make the "HGS Members" and "HGS Student Members" rows in the conference 2026 registration fees table link to the society registration page, so attendees see how to qualify for the reduced rate.
- Point `siteConfig.social.facebook` (used by the footer) to the canonical `facebook.com/HellenicGEOSOCIETY` URL, replacing the legacy `profile.php?id=61558192471144` link. The Contact pages already used the canonical URL.

## Notes for reviewers
- Link styling uses a subtle underline with `decoration-black/20` that darkens on hover, matching the understated palette of the fees table — no colored link text.
- `validLocale` was already in scope in the conference page, so the href stays locale-aware.
- Only one source of truth needed updating for the Facebook link (`src/config/site.ts`); grep confirmed no other references to the legacy URL.

## Test plan
- [ ] Visit `/en/conference2026` and `/el/conference2026`; confirm the two HGS Member rows are underlined links and clicking them navigates to `/{locale}/society/registration`.
- [ ] Confirm row layout (category / early bird / late bird columns) is unchanged.
- [ ] Confirm the footer Facebook icon now opens `facebook.com/HellenicGEOSOCIETY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)