### PR TITLE
Clean up fees label and add Karymbalis to scientific committee

### DIFF
--- a/src/app/[locale]/conference2026/page.tsx
+++ b/src/app/[locale]/conference2026/page.tsx
@@ -579,8 +579,7 @@ export default async function Conference2026Page({ params }: PageProps) {
                             className="font-medium text-black underline underline-offset-4 decoration-black/20 hover:decoration-black transition-colors"
                           >
                             HGS Members
-                          </Link>{" "}
-                          <span className="text-xs text-black/40">(in good standing)</span>
+                          </Link>
                         </td>
                         <td className="py-3 pr-4 font-medium">€40</td>
                         <td className="py-3 text-black/40">€50</td>

--- a/src/app/[locale]/conference2026/page.tsx
+++ b/src/app/[locale]/conference2026/page.tsx
@@ -243,6 +243,10 @@ const scientificCommittee = [
     url: "https://www.ekke.gr/en/centre/personnel/kandilis-georgios",
   },
   {
+    name: "Efthimios Karymbalis",
+    url: "https://geo.hua.gr/personnel/efthymios-karybalis/",
+  },
+  {
     name: "Dimitris Kavroudakis",
     url: "https://geography.aegean.gr/ppl/index.php?content=0&bio=dimitrisk",
   },


### PR DESCRIPTION
## Summary
- Drop the redundant "(in good standing)" qualifier from the HGS Members row in the conference 2026 fees table. The row is now a link to the society registration page, which conveys the same meaning more cleanly.
- Add **Efthimios Karymbalis** ([geo.hua.gr](https://geo.hua.gr/personnel/efthymios-karybalis/)) to the scientific committee.

## Notes for reviewers
- Karymbalis is inserted between Kandylis and Kavroudakis in the source array to preserve alphabetical-by-last-name ordering. The rendered list is also sorted at runtime, so position-in-source is cosmetic.
- These two commits were originally pushed to the `link-member-fees-and-fb-url` branch after PR #2 had already been merged, so they were stranded on a closed branch. Cherry-picked onto a fresh branch here so they can be merged.

## Test plan
- [ ] Confirm the HGS Members row no longer shows "(in good standing)".
- [ ] Confirm "Efthimios Karymbalis" appears as a clickable chip in the scientific committee, alphabetically between Kandylis and Kavroudakis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)