### PR TITLE
Add /database admin inspection page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,11 @@ if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_A
 }
 
 const nextConfig: NextConfig = {
+  // WARNING: Only NEXT_PUBLIC_* vars belong in this block. Values listed here
+  // are inlined into the client bundle at build time. NEVER add
+  // SUPABASE_SERVICE_ROLE_KEY, HGS_ADMIN_PASSWORD, or HGS_ADMIN_SESSION_SECRET
+  // here — they must stay server-only. Read those via `process.env.*` inside
+  // route handlers / `src/lib/supabase-admin.ts` / `src/lib/admin-session.ts`.
   env: {
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@supabase/supabase-js": "^2.93.3",
+        "@types/archiver": "^7.0.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
+        "archiver": "^7.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.26.2",
@@ -30,6 +32,7 @@
         "remark-html": "^16.0.1",
         "resend": "^6.9.3",
         "tailwind-merge": "^3.4.0",
+        "xlsx": "^0.18.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -1042,6 +1045,23 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1295,6 +1315,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -2448,6 +2478,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2535,6 +2574,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -3168,6 +3216,18 @@
         }
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3191,6 +3251,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3208,11 +3277,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3222,6 +3302,42 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/argparse": {
@@ -3420,6 +3536,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3466,6 +3588,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -3480,7 +3616,117 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -3548,6 +3794,39 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/call-bind": {
@@ -3640,6 +3919,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3714,11 +4006,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3731,7 +4031,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -3742,6 +4041,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/concat-map": {
@@ -3758,11 +4073,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3980,6 +4325,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -3991,7 +4342,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -4645,6 +4995,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4668,6 +5045,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4808,6 +5191,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/framer-motion": {
@@ -4977,6 +5385,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4988,6 +5417,30 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -5037,7 +5490,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/gray-matter": {
@@ -5258,6 +5710,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5294,6 +5766,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5503,6 +5981,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -5649,6 +6136,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -5757,7 +6256,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -5776,6 +6274,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -5908,6 +6421,54 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/levn": {
@@ -6200,6 +6761,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6852,6 +7419,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.26.2",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.26.2.tgz",
@@ -7001,6 +7577,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7193,6 +7778,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7220,7 +7811,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7232,6 +7822,28 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7306,6 +7918,21 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7471,6 +8098,52 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7698,6 +8371,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -7873,7 +8566,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7886,7 +8578,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7968,6 +8659,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7992,6 +8695,18 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -8022,6 +8737,85 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -8151,6 +8945,43 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -8271,6 +9102,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tinyglobby": {
@@ -8769,6 +9630,12 @@
         }
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -8814,7 +9681,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8915,6 +9781,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8923,6 +9807,94 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {
@@ -8946,6 +9918,27 @@
         }
       }
     },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -8964,6 +9957,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/supabase-js": "^2.93.3",
+    "@types/archiver": "^7.0.0",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
+    "archiver": "^7.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.26.2",
@@ -31,6 +33,7 @@
     "remark-html": "^16.0.1",
     "resend": "^6.9.3",
     "tailwind-merge": "^3.4.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  SESSION_COOKIE,
+  clearSessionCookieAttributes,
+  sessionCookieAttributes,
+  signSession,
+  verifySession,
+} from "@/lib/admin-session";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  if (ab.length !== bb.length) return false;
+  let diff = 0;
+  for (let i = 0; i < ab.length; i++) diff |= ab[i] ^ bb[i];
+  return diff === 0;
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const expected = process.env.HGS_ADMIN_PASSWORD;
+  if (!expected) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  let body: { password?: unknown } = {};
+  try {
+    body = (await request.json()) as { password?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const password = typeof body.password === "string" ? body.password : "";
+
+  const ip = getClientIp(request);
+  const ua = request.headers.get("user-agent") ?? "unknown";
+
+  if (!timingSafeStringEqual(password, expected)) {
+    await sleep(500);
+    console.warn(`[admin][auth] failed login from ip=${ip} ua="${ua}"`);
+    return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+  }
+
+  console.info(`[admin][auth] successful login from ip=${ip} ua="${ua}"`);
+
+  const token = await signSession();
+  const res = NextResponse.json({ ok: true });
+  res.headers.append(
+    "Set-Cookie",
+    `${SESSION_COOKIE}=${token}; ${sessionCookieAttributes()}`,
+  );
+  return res;
+}
+
+export async function DELETE() {
+  const res = NextResponse.json({ ok: true });
+  res.headers.append(
+    "Set-Cookie",
+    `${SESSION_COOKIE}=; ${clearSessionCookieAttributes()}`,
+  );
+  return res;
+}
+
+export async function GET(request: NextRequest) {
+  const cookie = request.cookies.get(SESSION_COOKIE)?.value;
+  const valid = await verifySession(cookie);
+  if (!valid) {
+    return NextResponse.json({ authenticated: false }, { status: 401 });
+  }
+  return NextResponse.json({ authenticated: true });
+}

--- a/src/app/api/admin/data/route.ts
+++ b/src/app/api/admin/data/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const sb = getSupabaseAdmin();
+
+  const [membership, registrations, abstracts, sessions, receipts] = await Promise.all([
+    sb
+      .from("membership_applications")
+      .select("*")
+      .order("created_at", { ascending: false }),
+    sb.from("registrations").select("*").order("created_at", { ascending: false }),
+    sb.from("abstracts").select("*").order("created_at", { ascending: false }),
+    sb
+      .from("thematic_session_submissions_2026")
+      .select("*")
+      .order("created_at", { ascending: false }),
+    sb.from("payment_receipts").select("*").order("created_at", { ascending: false }),
+  ]);
+
+  const errors = [membership, registrations, abstracts, sessions, receipts]
+    .map((r) => r.error)
+    .filter(Boolean);
+  if (errors.length > 0) {
+    console.error("[admin][data] supabase errors:", errors);
+    return NextResponse.json({ error: "Failed to fetch data" }, { status: 500 });
+  }
+
+  const allReceipts = receipts.data ?? [];
+
+  return NextResponse.json({
+    membership: {
+      registrations: membership.data ?? [],
+      receipts: allReceipts.filter((r) => r.receipt_type === "hgs_membership"),
+    },
+    conference: {
+      sessions: sessions.data ?? [],
+      abstracts: abstracts.data ?? [],
+      receipts: allReceipts.filter((r) => r.receipt_type === "conference"),
+    },
+  });
+}

--- a/src/app/api/admin/export/xlsx/route.ts
+++ b/src/app/api/admin/export/xlsx/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse, type NextRequest } from "next/server";
+import * as XLSX from "xlsx";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+type TableKey =
+  | "membership_applications"
+  | "registrations"
+  | "abstracts"
+  | "thematic_session_submissions_2026"
+  | "payment_receipts_membership"
+  | "payment_receipts_conference";
+
+const FILENAMES: Record<TableKey, string> = {
+  membership_applications: "hgs-membership-registrations",
+  registrations: "hgs-conference-registrations",
+  abstracts: "hgs-conference-abstracts",
+  thematic_session_submissions_2026: "hgs-conference-thematic-sessions",
+  payment_receipts_membership: "hgs-membership-receipts",
+  payment_receipts_conference: "hgs-conference-receipts",
+};
+
+function serializeRow(row: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(row)) {
+    if (v === null || v === undefined) out[k] = "";
+    else if (typeof v === "object") out[k] = JSON.stringify(v);
+    else out[k] = v;
+  }
+  return out;
+}
+
+async function fetchTable(key: TableKey): Promise<Record<string, unknown>[]> {
+  const sb = getSupabaseAdmin();
+  if (key === "payment_receipts_membership") {
+    const { data, error } = await sb
+      .from("payment_receipts")
+      .select("*")
+      .eq("receipt_type", "hgs_membership")
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return data ?? [];
+  }
+  if (key === "payment_receipts_conference") {
+    const { data, error } = await sb
+      .from("payment_receipts")
+      .select("*")
+      .eq("receipt_type", "conference")
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return data ?? [];
+  }
+  const { data, error } = await sb
+    .from(key)
+    .select("*")
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function GET(request: NextRequest) {
+  const table = request.nextUrl.searchParams.get("table") as TableKey | null;
+  if (!table || !(table in FILENAMES)) {
+    return NextResponse.json({ error: "Invalid table" }, { status: 400 });
+  }
+
+  let rows: Record<string, unknown>[];
+  try {
+    rows = await fetchTable(table);
+  } catch (err) {
+    console.error("[admin][export-xlsx] fetch error:", err);
+    return NextResponse.json({ error: "Failed to fetch data" }, { status: 500 });
+  }
+
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet(rows.map(serializeRow));
+  XLSX.utils.book_append_sheet(wb, ws, "Sheet1");
+  const buffer = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const filename = `${FILENAMES[table]}-${today}.xlsx`;
+
+  return new NextResponse(new Uint8Array(buffer), {
+    status: 200,
+    headers: {
+      "Content-Type":
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/api/admin/export/zip/route.ts
+++ b/src/app/api/admin/export/zip/route.ts
@@ -1,0 +1,213 @@
+import { NextResponse, type NextRequest } from "next/server";
+import archiver from "archiver";
+import * as XLSX from "xlsx";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+type Section = "membership" | "conference";
+
+function serializeRow(row: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(row)) {
+    if (v === null || v === undefined) out[k] = "";
+    else if (typeof v === "object") out[k] = JSON.stringify(v);
+    else out[k] = v;
+  }
+  return out;
+}
+
+function sheetBuffer(rows: Record<string, unknown>[], sheetName: string): Buffer {
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet(rows.map(serializeRow));
+  XLSX.utils.book_append_sheet(wb, ws, sheetName);
+  return XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
+}
+
+function safeFileName(s: string): string {
+  return s.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+export async function GET(request: NextRequest) {
+  const section = request.nextUrl.searchParams.get("section") as Section | null;
+  if (section !== "membership" && section !== "conference") {
+    return NextResponse.json({ error: "Invalid section" }, { status: 400 });
+  }
+
+  const sb = getSupabaseAdmin();
+
+  const errors: string[] = [];
+  const today = new Date().toISOString().slice(0, 10);
+  const archive = archiver("zip", { zlib: { level: 9 } });
+  archive.on("error", (err) => {
+    console.error("[admin][export-zip] archive error:", err);
+  });
+  archive.on("warning", (err) => {
+    console.warn("[admin][export-zip] archive warning:", err);
+  });
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      archive.on("data", (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
+      archive.on("end", () => controller.close());
+      archive.on("error", (err) => controller.error(err));
+
+      (async () => {
+        try {
+          if (section === "membership") {
+            const [regs, receipts] = await Promise.all([
+              sb
+                .from("membership_applications")
+                .select("*")
+                .order("created_at", { ascending: false }),
+              sb
+                .from("payment_receipts")
+                .select("*")
+                .eq("receipt_type", "hgs_membership")
+                .order("created_at", { ascending: false }),
+            ]);
+            if (regs.error || receipts.error) throw regs.error ?? receipts.error;
+
+            archive.append(
+              sheetBuffer(regs.data ?? [], "Registrations"),
+              { name: "membership-registrations.xlsx" },
+            );
+            archive.append(
+              sheetBuffer(receipts.data ?? [], "Receipts"),
+              { name: "membership-receipts.xlsx" },
+            );
+
+            for (const row of regs.data ?? []) {
+              const path = (row as { receipt_path?: string }).receipt_path;
+              const email = String((row as { email?: string }).email ?? "unknown");
+              if (!path) continue;
+              try {
+                const { data, error } = await sb.storage
+                  .from("membership-receipts")
+                  .download(path);
+                if (error || !data) throw error ?? new Error("empty download");
+                const buf = Buffer.from(await data.arrayBuffer());
+                const ext = path.split(".").pop() ?? "bin";
+                archive.append(buf, {
+                  name: `registration-receipts/${safeFileName(email)}.${ext}`,
+                });
+              } catch (e) {
+                errors.push(
+                  `membership-receipts/${path}: ${e instanceof Error ? e.message : String(e)}`,
+                );
+              }
+            }
+
+            for (const row of receipts.data ?? []) {
+              const path = (row as { file_path?: string }).file_path;
+              const email = String((row as { email?: string }).email ?? "unknown");
+              if (!path) continue;
+              try {
+                const { data, error } = await sb.storage
+                  .from("payment-receipts")
+                  .download(path);
+                if (error || !data) throw error ?? new Error("empty download");
+                const buf = Buffer.from(await data.arrayBuffer());
+                const ext = path.split(".").pop() ?? "bin";
+                archive.append(buf, {
+                  name: `payment-receipts/${safeFileName(email)}.${ext}`,
+                });
+              } catch (e) {
+                errors.push(
+                  `payment-receipts/${path}: ${e instanceof Error ? e.message : String(e)}`,
+                );
+              }
+            }
+          } else {
+            const [sessions, abstracts, receipts] = await Promise.all([
+              sb
+                .from("thematic_session_submissions_2026")
+                .select("*")
+                .order("created_at", { ascending: false }),
+              sb
+                .from("abstracts")
+                .select("*")
+                .order("created_at", { ascending: false }),
+              sb
+                .from("payment_receipts")
+                .select("*")
+                .eq("receipt_type", "conference")
+                .order("created_at", { ascending: false }),
+            ]);
+            if (sessions.error || abstracts.error || receipts.error) {
+              throw sessions.error ?? abstracts.error ?? receipts.error;
+            }
+
+            archive.append(
+              sheetBuffer(sessions.data ?? [], "ThematicSessions"),
+              { name: "conference-thematic-sessions.xlsx" },
+            );
+            archive.append(
+              sheetBuffer(abstracts.data ?? [], "Abstracts"),
+              { name: "conference-abstracts.xlsx" },
+            );
+            archive.append(
+              sheetBuffer(receipts.data ?? [], "Receipts"),
+              { name: "conference-receipts.xlsx" },
+            );
+
+            for (const row of receipts.data ?? []) {
+              const path = (row as { file_path?: string }).file_path;
+              const email = String((row as { email?: string }).email ?? "unknown");
+              if (!path) continue;
+              try {
+                const { data, error } = await sb.storage
+                  .from("payment-receipts")
+                  .download(path);
+                if (error || !data) throw error ?? new Error("empty download");
+                const buf = Buffer.from(await data.arrayBuffer());
+                const ext = path.split(".").pop() ?? "bin";
+                archive.append(buf, {
+                  name: `payment-receipts/${safeFileName(email)}.${ext}`,
+                });
+              } catch (e) {
+                errors.push(
+                  `payment-receipts/${path}: ${e instanceof Error ? e.message : String(e)}`,
+                );
+              }
+            }
+          }
+
+          const readme = [
+            `HGS ${section === "membership" ? "Membership" : "Conference 2026"} export`,
+            `Generated: ${new Date().toISOString()}`,
+            "",
+            errors.length === 0
+              ? "All files included successfully."
+              : `Errors (${errors.length}):\n${errors.map((e) => `- ${e}`).join("\n")}`,
+          ].join("\n");
+          archive.append(readme, { name: "README.txt" });
+
+          await archive.finalize();
+        } catch (err) {
+          console.error("[admin][export-zip] fatal:", err);
+          try {
+            controller.error(err);
+          } catch {
+            /* already errored */
+          }
+        }
+      })();
+    },
+    cancel() {
+      archive.abort();
+    },
+  });
+
+  const filename = `hgs-${section}-export-${today}.zip`;
+  return new NextResponse(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/api/admin/file-url/route.ts
+++ b/src/app/api/admin/file-url/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase-admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const ALLOWED_BUCKETS = new Set(["membership-receipts", "payment-receipts"]);
+const SIGNED_URL_TTL_SECONDS = 300;
+
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+export async function POST(request: NextRequest) {
+  let body: { bucket?: unknown; path?: unknown } = {};
+  try {
+    body = (await request.json()) as { bucket?: unknown; path?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const bucket = typeof body.bucket === "string" ? body.bucket : "";
+  const path = typeof body.path === "string" ? body.path : "";
+
+  if (!ALLOWED_BUCKETS.has(bucket)) {
+    return NextResponse.json({ error: "Invalid bucket" }, { status: 400 });
+  }
+  if (!path || path.includes("..") || path.startsWith("/")) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  const { data, error } = await getSupabaseAdmin()
+    .storage.from(bucket)
+    .createSignedUrl(path, SIGNED_URL_TTL_SECONDS);
+
+  if (error || !data) {
+    console.error("[admin][file-url] sign error:", error);
+    return NextResponse.json({ error: "Failed to sign URL" }, { status: 500 });
+  }
+
+  console.info(
+    `[admin][file-url] signed bucket=${bucket} path=${path} ip=${getClientIp(request)}`,
+  );
+  return NextResponse.json({ url: data.signedUrl });
+}

--- a/src/app/database/_components/Dashboard.tsx
+++ b/src/app/database/_components/Dashboard.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  Download,
+  FileSpreadsheet,
+  Loader2,
+  LogOut,
+  RefreshCw,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { DataTable } from "./DataTable";
+import { DetailDialog } from "./DetailDialog";
+import {
+  exportXlsxUrl,
+  exportZipUrl,
+  fetchDashboardData,
+  logout,
+} from "../_lib/api";
+import {
+  conferenceAbstractsColumns,
+  conferenceReceiptsColumns,
+  conferenceSessionsColumns,
+  membershipReceiptsColumns,
+  membershipRegistrationsColumns,
+} from "../_lib/columns";
+import { formatDateTime, formatOrganizer, fullName, humanBool } from "../_lib/format";
+import type {
+  Abstract,
+  DashboardData,
+  ExportTableKey,
+  MembershipApplication,
+  PaymentReceipt,
+  SectionKey,
+  TabKey,
+  ThematicSessionSubmission,
+} from "../_lib/types";
+
+type SelectedRow =
+  | { kind: "membership-registration"; row: MembershipApplication }
+  | { kind: "membership-receipt"; row: PaymentReceipt }
+  | { kind: "conference-session"; row: ThematicSessionSubmission }
+  | { kind: "conference-abstract"; row: Abstract }
+  | { kind: "conference-receipt"; row: PaymentReceipt };
+
+const SECTION_LABEL: Record<SectionKey, string> = {
+  membership: "HGS Membership",
+  conference: "Conference 2026",
+};
+
+const TABS_BY_SECTION: Record<SectionKey, { key: TabKey; label: string }[]> = {
+  membership: [
+    { key: "membership-registrations", label: "Registrations" },
+    { key: "membership-receipts", label: "Receipts" },
+  ],
+  conference: [
+    { key: "conference-sessions", label: "Thematic Sessions" },
+    { key: "conference-abstracts", label: "Abstracts" },
+    { key: "conference-receipts", label: "Receipts" },
+  ],
+};
+
+const TAB_EXPORT_TABLE: Record<TabKey, ExportTableKey> = {
+  "membership-registrations": "membership_applications",
+  "membership-receipts": "payment_receipts_membership",
+  "conference-sessions": "thematic_session_submissions_2026",
+  "conference-abstracts": "abstracts",
+  "conference-receipts": "payment_receipts_conference",
+};
+
+export function Dashboard() {
+  const router = useRouter();
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [section, setSection] = useState<SectionKey>("membership");
+  const [tab, setTab] = useState<TabKey>("membership-registrations");
+  const [selected, setSelected] = useState<SelectedRow | null>(null);
+
+  const load = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      const d = await fetchDashboardData();
+      setData(d);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to load data";
+      setError(msg);
+      if (msg === "Unauthorized" || msg === "HTTP 401") {
+        router.replace("/database/login");
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [router]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function switchSection(next: SectionKey) {
+    if (next === section) return;
+    setSection(next);
+    setTab(TABS_BY_SECTION[next][0].key);
+  }
+
+  async function handleLogout() {
+    await logout();
+    router.replace("/database/login");
+    router.refresh();
+  }
+
+  const tabsForSection = TABS_BY_SECTION[section];
+
+  const activeTable = useMemo(() => {
+    if (!data) return null;
+
+    const rowClick = <T,>(row: T, kind: SelectedRow["kind"]) => {
+      setSelected({ kind, row } as SelectedRow);
+    };
+
+    switch (tab) {
+      case "membership-registrations": {
+        const rows = data.membership.registrations;
+        return (
+          <DataTable<MembershipApplication>
+            columns={membershipRegistrationsColumns}
+            rows={rows}
+            rowKey={(r) => `${r.email}-${r.created_at}`}
+            searchable={(r) =>
+              `${r.first_name} ${r.last_name} ${r.email} ${r.affiliation ?? ""} ${r.country ?? ""} ${r.role ?? ""}`
+            }
+            onRowClick={(r) => rowClick(r, "membership-registration")}
+            emptyMessage="No membership applications yet."
+          />
+        );
+      }
+      case "membership-receipts": {
+        const rows = data.membership.receipts;
+        return (
+          <DataTable<PaymentReceipt>
+            columns={membershipReceiptsColumns}
+            rows={rows}
+            rowKey={(r) => `${r.email}-${r.file_path}-${r.created_at}`}
+            searchable={(r) => `${r.email} ${r.notes ?? ""} ${r.file_path}`}
+            onRowClick={(r) => rowClick(r, "membership-receipt")}
+            emptyMessage="No membership receipts yet."
+          />
+        );
+      }
+      case "conference-sessions": {
+        const rows = data.conference.sessions;
+        return (
+          <DataTable<ThematicSessionSubmission>
+            columns={conferenceSessionsColumns}
+            rows={rows}
+            rowKey={(r) => `${r.session_title}-${r.created_at}`}
+            searchable={(r) =>
+              `${r.session_title} ${r.session_topic} ${formatOrganizer(r.organizer_primary)} ${(r.session_keywords ?? []).join(" ")}`
+            }
+            onRowClick={(r) => rowClick(r, "conference-session")}
+            emptyMessage="No thematic session submissions."
+          />
+        );
+      }
+      case "conference-abstracts": {
+        const rows = data.conference.abstracts;
+        return (
+          <DataTable<Abstract>
+            columns={conferenceAbstractsColumns}
+            rows={rows}
+            rowKey={(r) => `${r.email}-${r.title}-${r.created_at}`}
+            searchable={(r) =>
+              `${r.title} ${r.first_name} ${r.last_name} ${r.email} ${r.affiliation} ${r.session} ${r.co_authors ?? ""}`
+            }
+            onRowClick={(r) => rowClick(r, "conference-abstract")}
+            emptyMessage="No abstracts yet."
+          />
+        );
+      }
+      case "conference-receipts": {
+        const rows = data.conference.receipts;
+        return (
+          <DataTable<PaymentReceipt>
+            columns={conferenceReceiptsColumns}
+            rows={rows}
+            rowKey={(r) => `${r.email}-${r.file_path}-${r.created_at}`}
+            searchable={(r) => `${r.email} ${r.notes ?? ""} ${r.file_path}`}
+            onRowClick={(r) => rowClick(r, "conference-receipt")}
+            emptyMessage="No conference receipts yet."
+          />
+        );
+      }
+    }
+  }, [data, tab]);
+
+  return (
+    <>
+      {/* Top bar */}
+      <header className="sticky top-0 z-40 border-b border-black/10 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex h-16 max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
+          <Link href="/en" className="flex items-center gap-2 shrink-0" aria-label="HGS home">
+            <Image src="/logo.png" alt="" width={32} height={32} className="h-8 w-8 object-contain" />
+            <span className="hidden font-semibold tracking-tight sm:inline">HGS Database</span>
+          </Link>
+
+          <nav className="ml-2 flex-1 overflow-x-auto" aria-label="Section">
+            <div className="inline-flex rounded-full border border-black/10 bg-neutral-50 p-1">
+              {(Object.keys(SECTION_LABEL) as SectionKey[]).map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => switchSection(s)}
+                  className={cn(
+                    "rounded-full px-3 py-1.5 text-xs font-medium transition-colors sm:text-sm sm:px-4",
+                    section === s
+                      ? "bg-primary text-primary-foreground"
+                      : "text-black/70 hover:text-black",
+                  )}
+                  aria-pressed={section === s}
+                >
+                  {SECTION_LABEL[s]}
+                </button>
+              ))}
+            </div>
+          </nav>
+
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void load(true)}
+              disabled={refreshing}
+              className="hidden sm:inline-flex"
+            >
+              {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+              <span className="hidden md:inline">Refresh</span>
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => void handleLogout()}>
+              <LogOut className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Logout</span>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 pb-16 pt-6 sm:px-6 lg:px-8">
+        {/* Tab strip + section-level export */}
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-wrap gap-1.5" role="tablist">
+            {tabsForSection.map((t) => (
+              <button
+                key={t.key}
+                type="button"
+                role="tab"
+                aria-selected={tab === t.key}
+                onClick={() => setTab(t.key)}
+                className={cn(
+                  "rounded-md border px-3 py-1.5 text-xs font-medium transition-colors sm:text-sm",
+                  tab === t.key
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-black/10 bg-white text-black/70 hover:border-black/20 hover:text-black",
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button asChild variant="outline" size="sm">
+              <a href={exportXlsxUrl(TAB_EXPORT_TABLE[tab])} download>
+                <FileSpreadsheet className="h-3.5 w-3.5" /> Export Excel
+              </a>
+            </Button>
+            <Button asChild size="sm">
+              <a href={exportZipUrl(section)} download>
+                <Download className="h-3.5 w-3.5" /> Download ZIP
+              </a>
+            </Button>
+          </div>
+        </div>
+
+        {loading ? (
+          <TableSkeleton />
+        ) : error ? (
+          <div className="flex flex-col items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
+            <div className="text-sm text-red-700">{error}</div>
+            <Button variant="outline" size="sm" onClick={() => void load(true)}>
+              <RefreshCw className="h-3.5 w-3.5" /> Retry
+            </Button>
+          </div>
+        ) : (
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={tab}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+            >
+              {activeTable}
+            </motion.div>
+          </AnimatePresence>
+        )}
+      </main>
+
+      <DetailDialog
+        open={selected !== null}
+        onOpenChange={(open) => !open && setSelected(null)}
+        {...(selected ? detailProps(selected) : emptyDetailProps())}
+      />
+    </>
+  );
+}
+
+function emptyDetailProps() {
+  return { title: "", fields: [] };
+}
+
+function detailProps(sel: SelectedRow): {
+  title: string;
+  subtitle?: string;
+  fields: Array<{ label: string; value: unknown }>;
+  files?: Array<{ bucket: "membership-receipts" | "payment-receipts"; path: string; label?: string }>;
+} {
+  switch (sel.kind) {
+    case "membership-registration": {
+      const r = sel.row;
+      return {
+        title: fullName(r.first_name, r.last_name),
+        subtitle: r.email,
+        fields: [
+          { label: "Email", value: r.email },
+          { label: "Member type", value: r.member_type === "research_staff" ? "Research staff" : r.member_type === "student" ? "Student" : r.member_type },
+          { label: "Role", value: r.role },
+          { label: "Degree", value: r.degree },
+          { label: "Affiliation", value: r.affiliation },
+          { label: "Country", value: r.country },
+          { label: "GDPR consent", value: humanBool(r.gdpr_consent) },
+          { label: "Mailing consent", value: humanBool(r.mailing_consent) },
+          { label: "Submitted", value: formatDateTime(r.created_at) },
+        ],
+        files: r.receipt_path
+          ? [{ bucket: "membership-receipts", path: r.receipt_path, label: "Membership receipt" }]
+          : undefined,
+      };
+    }
+    case "membership-receipt":
+    case "conference-receipt": {
+      const r = sel.row;
+      return {
+        title: "Payment receipt",
+        subtitle: r.email,
+        fields: [
+          { label: "Email", value: r.email },
+          { label: "Type", value: r.receipt_type === "hgs_membership" ? "HGS Membership" : r.receipt_type === "conference" ? "Conference 2026" : r.receipt_type },
+          { label: "Notes", value: r.notes },
+          { label: "Submitted", value: formatDateTime(r.created_at) },
+        ],
+        files: [{ bucket: "payment-receipts", path: r.file_path, label: r.file_path.split("/").pop() }],
+      };
+    }
+    case "conference-session": {
+      const r = sel.row;
+      return {
+        title: r.session_title,
+        subtitle: r.session_topic,
+        fields: [
+          { label: "Locale", value: r.locale?.toUpperCase() },
+          { label: "Primary organizer", value: formatOrganizer(r.organizer_primary) },
+          { label: "Secondary organizer", value: r.organizer_secondary ? formatOrganizer(r.organizer_secondary) : null },
+          { label: "Tertiary organizer", value: r.organizer_tertiary ? formatOrganizer(r.organizer_tertiary) : null },
+          { label: "Keywords", value: r.session_keywords },
+          { label: "Summary", value: r.session_summary },
+          { label: "Additional comments", value: r.additional_comments },
+          { label: "Submitted", value: formatDateTime(r.created_at) },
+        ],
+      };
+    }
+    case "conference-abstract": {
+      const r = sel.row;
+      return {
+        title: r.title,
+        subtitle: fullName(r.first_name, r.last_name),
+        fields: [
+          { label: "Author", value: fullName(r.first_name, r.last_name) },
+          { label: "Email", value: r.email },
+          { label: "Affiliation", value: r.affiliation },
+          { label: "Session", value: r.session },
+          { label: "Co-authors", value: r.co_authors || null },
+          { label: "Abstract", value: r.abstract_text },
+          { label: "Notes", value: r.notes },
+          { label: "Submitted", value: formatDateTime(r.created_at) },
+        ],
+      };
+    }
+  }
+}
+
+function TableSkeleton() {
+  return (
+    <div className="space-y-2">
+      <div className="h-9 w-full max-w-sm animate-pulse rounded-lg bg-black/5" />
+      <div className="rounded-xl border border-black/10 bg-white">
+        <div className="divide-y divide-black/5">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="grid grid-cols-6 gap-4 px-4 py-4">
+              <div className="h-3 animate-pulse rounded bg-black/5 col-span-2" />
+              <div className="h-3 animate-pulse rounded bg-black/5" />
+              <div className="h-3 animate-pulse rounded bg-black/5" />
+              <div className="h-3 animate-pulse rounded bg-black/5" />
+              <div className="h-3 animate-pulse rounded bg-black/5" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/database/_components/DataTable.tsx
+++ b/src/app/database/_components/DataTable.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import type { ColumnDef } from "../_lib/columns";
+
+type SortDir = "asc" | "desc";
+
+interface Props<T> {
+  columns: ColumnDef<T>[];
+  rows: T[];
+  searchable?: (row: T) => string;
+  onRowClick: (row: T) => void;
+  emptyMessage?: string;
+  rowKey: (row: T) => string;
+}
+
+export function DataTable<T>({
+  columns,
+  rows,
+  searchable,
+  onRowClick,
+  emptyMessage = "No rows.",
+  rowKey,
+}: Props<T>) {
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [query, setQuery] = useState("");
+
+  const visibleRows = useMemo(() => {
+    let out = rows;
+    if (query.trim() && searchable) {
+      const q = query.trim().toLowerCase();
+      out = out.filter((r) => searchable(r).toLowerCase().includes(q));
+    }
+    if (sortKey) {
+      const col = columns.find((c) => c.key === sortKey);
+      if (col) {
+        const acc = col.accessor;
+        out = [...out].sort((a, b) => {
+          const av = acc(a);
+          const bv = acc(b);
+          if (av == null && bv == null) return 0;
+          if (av == null) return 1;
+          if (bv == null) return -1;
+          if (av < bv) return sortDir === "asc" ? -1 : 1;
+          if (av > bv) return sortDir === "asc" ? 1 : -1;
+          return 0;
+        });
+      }
+    }
+    return out;
+  }, [rows, query, sortKey, sortDir, columns, searchable]);
+
+  function toggleSort(key: string) {
+    if (sortKey !== key) {
+      setSortKey(key);
+      setSortDir("asc");
+      return;
+    }
+    setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+  }
+
+  return (
+    <div className="space-y-3">
+      {searchable && (
+        <div className="relative max-w-sm">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-black/40" />
+          <Input
+            type="search"
+            placeholder="Search…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="pl-9"
+            aria-label="Search rows"
+          />
+        </div>
+      )}
+
+      {/* Desktop table */}
+      <div className="hidden md:block overflow-x-auto rounded-xl border border-black/10 bg-white">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-black/10 bg-neutral-50 text-left">
+              {columns.map((col) => {
+                const active = sortKey === col.key;
+                return (
+                  <th
+                    key={col.key}
+                    className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-black/60"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(col.key)}
+                      className="inline-flex items-center gap-1 hover:text-black"
+                    >
+                      {col.header}
+                      {active ? (
+                        sortDir === "asc" ? (
+                          <ArrowUp className="h-3 w-3" />
+                        ) : (
+                          <ArrowDown className="h-3 w-3" />
+                        )
+                      ) : (
+                        <ArrowUpDown className="h-3 w-3 opacity-30" />
+                      )}
+                    </button>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {visibleRows.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="px-4 py-12 text-center text-sm text-black/50">
+                  {emptyMessage}
+                </td>
+              </tr>
+            ) : (
+              visibleRows.map((row) => (
+                <tr
+                  key={rowKey(row)}
+                  onClick={() => onRowClick(row)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onRowClick(row);
+                    }
+                  }}
+                  tabIndex={0}
+                  className="cursor-pointer border-b border-black/5 last:border-0 hover:bg-neutral-50 focus:bg-neutral-50 focus:outline-none"
+                >
+                  {columns.map((col) => (
+                    <td
+                      key={col.key}
+                      className={`px-4 py-3 align-top ${col.mono ? "font-mono text-xs" : ""} ${col.className ?? ""}`}
+                    >
+                      {col.cell ? col.cell(row) : (col.accessor(row) ?? "—")}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="md:hidden space-y-2">
+        {visibleRows.length === 0 ? (
+          <div className="rounded-xl border border-black/10 bg-white px-4 py-12 text-center text-sm text-black/50">
+            {emptyMessage}
+          </div>
+        ) : (
+          visibleRows.map((row) => (
+            <button
+              type="button"
+              key={rowKey(row)}
+              onClick={() => onRowClick(row)}
+              className="block w-full rounded-xl border border-black/10 bg-white p-4 text-left hover:border-black/20 active:bg-neutral-50"
+            >
+              <div className="space-y-1.5">
+                {columns.map((col) => (
+                  <div key={col.key} className="flex items-start justify-between gap-3 text-xs">
+                    <span className="text-black/50">{col.header}</span>
+                    <span
+                      className={`text-right ${col.mono ? "font-mono" : ""}`}
+                    >
+                      {col.cell ? col.cell(row) : (col.accessor(row) ?? "—")}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+
+      <div className="text-xs text-black/40 tabular-nums">
+        {visibleRows.length} row{visibleRows.length === 1 ? "" : "s"}
+        {query && rows.length !== visibleRows.length ? ` (filtered from ${rows.length})` : ""}
+      </div>
+    </div>
+  );
+}

--- a/src/app/database/_components/DetailDialog.tsx
+++ b/src/app/database/_components/DetailDialog.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Download, ExternalLink } from "lucide-react";
+import { downloadFile } from "../_lib/api";
+import { formatDateTime, humanBool } from "../_lib/format";
+
+interface FileRef {
+  bucket: "membership-receipts" | "payment-receipts";
+  path: string;
+  label?: string;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  subtitle?: string;
+  fields: Array<{ label: string; value: unknown }>;
+  files?: FileRef[];
+}
+
+function renderValue(value: unknown): React.ReactNode {
+  if (value === null || value === undefined || value === "") return <span className="text-black/40">—</span>;
+  if (typeof value === "boolean") return humanBool(value);
+  if (typeof value === "string") {
+    if (/^\d{4}-\d{2}-\d{2}T/.test(value)) return <span className="font-mono text-xs tabular-nums">{formatDateTime(value)}</span>;
+    return value;
+  }
+  if (typeof value === "number") return <span className="tabular-nums">{value}</span>;
+  if (Array.isArray(value)) return <span className="font-mono text-xs">{value.map((v) => String(v)).join(", ")}</span>;
+  if (typeof value === "object") {
+    return (
+      <pre className="whitespace-pre-wrap break-words rounded-md bg-neutral-50 p-2 text-xs font-mono">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+  return String(value);
+}
+
+export function DetailDialog({ open, onOpenChange, title, subtitle, fields, files }: Props) {
+  const [downloading, setDownloading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDownload(file: FileRef) {
+    setError(null);
+    setDownloading(file.path);
+    try {
+      await downloadFile(file.bucket, file.path);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Download failed");
+    } finally {
+      setDownloading(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="pr-8 text-left">{title}</DialogTitle>
+          {subtitle && <DialogDescription className="text-left">{subtitle}</DialogDescription>}
+        </DialogHeader>
+
+        {files && files.length > 0 && (
+          <div className="my-3 space-y-2 rounded-xl border border-black/10 bg-neutral-50 p-3">
+            <div className="text-xs font-medium uppercase tracking-wider text-black/50">
+              Attached files
+            </div>
+            {files.map((file) => (
+              <div key={file.path} className="flex items-center justify-between gap-3 text-xs">
+                <div className="min-w-0 flex-1 font-mono truncate" title={file.path}>
+                  {file.label ?? file.path.split("/").pop()}
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleDownload(file)}
+                  disabled={downloading === file.path}
+                  className="shrink-0"
+                >
+                  {downloading === file.path ? (
+                    <>
+                      <ExternalLink className="mr-1 h-3 w-3" /> Opening…
+                    </>
+                  ) : (
+                    <>
+                      <Download className="mr-1 h-3 w-3" /> Download
+                    </>
+                  )}
+                </Button>
+              </div>
+            ))}
+            {error && <div className="text-xs text-red-600">{error}</div>}
+          </div>
+        )}
+
+        <dl className="divide-y divide-black/5">
+          {fields.map((field) => (
+            <div key={field.label} className="grid grid-cols-1 gap-1 py-2.5 sm:grid-cols-[11rem_1fr] sm:gap-4">
+              <dt className="text-xs font-medium uppercase tracking-wider text-black/50 sm:pt-0.5">
+                {field.label}
+              </dt>
+              <dd className="min-w-0 break-words text-sm">{renderValue(field.value)}</dd>
+            </div>
+          ))}
+        </dl>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/database/_components/LoginForm.tsx
+++ b/src/app/database/_components/LoginForm.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { login } from "../_lib/api";
+
+export function LoginForm() {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      await login(password);
+      router.replace("/database");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Login failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm rounded-2xl border border-black/10 bg-white p-8 shadow-sm"
+      >
+        <div className="mb-6 flex flex-col items-center gap-1">
+          <div className="text-xs font-mono uppercase tracking-wider text-black/50">
+            Hellenic Geographical Society
+          </div>
+          <h1 className="text-2xl font-semibold tracking-tight">Database</h1>
+          <p className="text-xs text-black/50">Authorized personnel only.</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoFocus
+          />
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700"
+          >
+            {error}
+          </div>
+        )}
+
+        <Button type="submit" disabled={busy || !password} className="mt-6 w-full">
+          {busy ? "Signing in…" : "Sign in"}
+        </Button>
+
+        <p className="mt-6 text-center text-[11px] leading-relaxed text-black/40">
+          This is an internal tool. All access is logged.
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/app/database/_lib/api.ts
+++ b/src/app/database/_lib/api.ts
@@ -1,0 +1,64 @@
+import type { DashboardData, ExportTableKey, SectionKey } from "./types";
+
+async function json<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      /* ignore */
+    }
+    throw new Error(message);
+  }
+  return (await res.json()) as T;
+}
+
+export async function login(password: string): Promise<void> {
+  const res = await fetch("/api/admin/auth", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ password }),
+  });
+  await json<{ ok: true }>(res);
+}
+
+export async function logout(): Promise<void> {
+  await fetch("/api/admin/auth", { method: "DELETE", credentials: "include" });
+}
+
+export async function fetchDashboardData(): Promise<DashboardData> {
+  const res = await fetch("/api/admin/data", { credentials: "include" });
+  return json<DashboardData>(res);
+}
+
+export async function getSignedFileUrl(
+  bucket: "membership-receipts" | "payment-receipts",
+  path: string,
+): Promise<string> {
+  const res = await fetch("/api/admin/file-url", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ bucket, path }),
+  });
+  const body = await json<{ url: string }>(res);
+  return body.url;
+}
+
+export function exportXlsxUrl(table: ExportTableKey): string {
+  return `/api/admin/export/xlsx?table=${encodeURIComponent(table)}`;
+}
+
+export function exportZipUrl(section: SectionKey): string {
+  return `/api/admin/export/zip?section=${encodeURIComponent(section)}`;
+}
+
+export async function downloadFile(
+  bucket: "membership-receipts" | "payment-receipts",
+  path: string,
+): Promise<void> {
+  const url = await getSignedFileUrl(bucket, path);
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/src/app/database/_lib/columns.tsx
+++ b/src/app/database/_lib/columns.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from "react";
+import type {
+  Abstract,
+  MembershipApplication,
+  PaymentReceipt,
+  ThematicSessionSubmission,
+} from "./types";
+import { formatDateTime, formatOrganizer, fullName, truncate } from "./format";
+
+export interface ColumnDef<T> {
+  key: string;
+  header: string;
+  accessor: (row: T) => string | number | null | undefined;
+  cell?: (row: T) => ReactNode;
+  mono?: boolean;
+  className?: string;
+}
+
+const dateCol = <T extends { created_at: string }>(): ColumnDef<T> => ({
+  key: "created_at",
+  header: "Submitted",
+  accessor: (r) => r.created_at,
+  cell: (r) => <span className="font-mono text-xs tabular-nums">{formatDateTime(r.created_at)}</span>,
+  className: "whitespace-nowrap",
+});
+
+export const membershipRegistrationsColumns: ColumnDef<MembershipApplication>[] = [
+  {
+    key: "name",
+    header: "Name",
+    accessor: (r) => `${r.last_name} ${r.first_name}`.toLowerCase(),
+    cell: (r) => <span className="font-medium">{fullName(r.first_name, r.last_name)}</span>,
+  },
+  {
+    key: "email",
+    header: "Email",
+    accessor: (r) => r.email,
+    mono: true,
+  },
+  {
+    key: "member_type",
+    header: "Type",
+    accessor: (r) => r.member_type,
+    cell: (r) => (
+      <span className="inline-flex rounded-full border border-black/10 bg-secondary px-2 py-0.5 text-xs">
+        {r.member_type === "research_staff" ? "Research staff" : r.member_type === "student" ? "Student" : r.member_type}
+      </span>
+    ),
+  },
+  { key: "role", header: "Role", accessor: (r) => r.role ?? "—" },
+  { key: "country", header: "Country", accessor: (r) => r.country ?? "—" },
+  { key: "affiliation", header: "Affiliation", accessor: (r) => r.affiliation ?? "—", cell: (r) => <span className="max-w-[14rem] truncate inline-block align-bottom">{r.affiliation ?? "—"}</span> },
+  dateCol<MembershipApplication>(),
+];
+
+export const membershipReceiptsColumns: ColumnDef<PaymentReceipt>[] = [
+  { key: "email", header: "Email", accessor: (r) => r.email, mono: true },
+  {
+    key: "file",
+    header: "File",
+    accessor: (r) => r.file_path,
+    cell: (r) => (
+      <span className="font-mono text-xs text-black/60">{r.file_path?.split("/").pop() ?? "—"}</span>
+    ),
+  },
+  { key: "notes", header: "Notes", accessor: (r) => r.notes ?? "—", cell: (r) => <span className="max-w-[18rem] truncate inline-block align-bottom">{truncate(r.notes, 60)}</span> },
+  dateCol<PaymentReceipt>(),
+];
+
+export const conferenceSessionsColumns: ColumnDef<ThematicSessionSubmission>[] = [
+  {
+    key: "session_title",
+    header: "Title",
+    accessor: (r) => r.session_title,
+    cell: (r) => <span className="font-medium">{truncate(r.session_title, 70)}</span>,
+  },
+  {
+    key: "session_topic",
+    header: "Topic",
+    accessor: (r) => r.session_topic,
+    cell: (r) => <span className="max-w-[12rem] truncate inline-block align-bottom">{truncate(r.session_topic, 40)}</span>,
+  },
+  {
+    key: "organizer",
+    header: "Primary organizer",
+    accessor: (r) => `${r.organizer_primary?.lastName ?? ""} ${r.organizer_primary?.firstName ?? ""}`.toLowerCase(),
+    cell: (r) => {
+      const extras = [r.organizer_secondary, r.organizer_tertiary].filter(Boolean).length;
+      return (
+        <span>
+          {formatOrganizer(r.organizer_primary)}
+          {extras > 0 && (
+            <span className="ml-2 inline-flex rounded-full border border-black/10 bg-secondary px-1.5 py-0.5 text-[10px] text-black/70">
+              +{extras} co-organizer{extras > 1 ? "s" : ""}
+            </span>
+          )}
+        </span>
+      );
+    },
+  },
+  { key: "locale", header: "Locale", accessor: (r) => r.locale, className: "uppercase text-xs font-mono" },
+  dateCol<ThematicSessionSubmission>(),
+];
+
+export const conferenceAbstractsColumns: ColumnDef<Abstract>[] = [
+  {
+    key: "title",
+    header: "Title",
+    accessor: (r) => r.title,
+    cell: (r) => <span className="font-medium">{truncate(r.title, 70)}</span>,
+  },
+  {
+    key: "name",
+    header: "Author",
+    accessor: (r) => `${r.last_name} ${r.first_name}`.toLowerCase(),
+    cell: (r) => fullName(r.first_name, r.last_name),
+  },
+  { key: "email", header: "Email", accessor: (r) => r.email, mono: true },
+  {
+    key: "affiliation",
+    header: "Affiliation",
+    accessor: (r) => r.affiliation,
+    cell: (r) => <span className="max-w-[14rem] truncate inline-block align-bottom">{r.affiliation}</span>,
+  },
+  {
+    key: "session",
+    header: "Session",
+    accessor: (r) => r.session,
+    cell: (r) => <span className="max-w-[12rem] truncate inline-block align-bottom text-xs text-black/70">{truncate(r.session, 40)}</span>,
+  },
+  dateCol<Abstract>(),
+];
+
+export const conferenceReceiptsColumns: ColumnDef<PaymentReceipt>[] = membershipReceiptsColumns;

--- a/src/app/database/_lib/format.ts
+++ b/src/app/database/_lib/format.ts
@@ -1,0 +1,49 @@
+import type { Organizer } from "./types";
+
+export function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function fullName(first: string | null | undefined, last: string | null | undefined): string {
+  const f = (first ?? "").trim();
+  const l = (last ?? "").trim();
+  if (!f && !l) return "—";
+  return `${l}${l && f ? ", " : ""}${f}`;
+}
+
+export function formatOrganizer(o: Organizer | null | undefined): string {
+  if (!o) return "—";
+  const name = fullName(o.firstName, o.lastName);
+  return o.email ? `${name} <${o.email}>` : name;
+}
+
+export function extensionFromPath(path: string | null | undefined): string {
+  if (!path) return "";
+  const dot = path.lastIndexOf(".");
+  if (dot === -1) return "";
+  return path.slice(dot + 1).toLowerCase();
+}
+
+export function humanBool(v: boolean | null | undefined): string {
+  if (v === true) return "Yes";
+  if (v === false) return "No";
+  return "—";
+}
+
+export function truncate(s: string | null | undefined, max = 80): string {
+  if (!s) return "—";
+  const t = s.trim();
+  return t.length > max ? `${t.slice(0, max - 1)}…` : t;
+}

--- a/src/app/database/_lib/types.ts
+++ b/src/app/database/_lib/types.ts
@@ -1,0 +1,103 @@
+export interface MembershipApplication {
+  id?: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  member_type: "research_staff" | "student" | string;
+  role: string | null;
+  degree: string | null;
+  affiliation: string | null;
+  country: string | null;
+  receipt_path: string | null;
+  gdpr_consent: boolean;
+  mailing_consent: boolean;
+  created_at: string;
+}
+
+export interface Registration {
+  id?: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  affiliation: string;
+  country: string;
+  registration_type: "regular" | "hgs_member" | "student" | "hgs_student" | string;
+  abstract_intent: "yes" | "no" | string;
+  mailing_consent: boolean;
+  gdpr_consent: boolean;
+  created_at: string;
+}
+
+export interface Abstract {
+  id?: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  affiliation: string;
+  session: string;
+  title: string;
+  co_authors: string;
+  abstract_text: string;
+  notes: string | null;
+  created_at: string;
+}
+
+export interface Organizer {
+  firstName: string;
+  lastName: string;
+  affiliation: string;
+  email: string;
+  country: string;
+}
+
+export interface ThematicSessionSubmission {
+  id?: string;
+  locale: "en" | "el" | string;
+  organizer_primary: Organizer;
+  organizer_secondary: Organizer | null;
+  organizer_tertiary: Organizer | null;
+  session_title: string;
+  session_topic: string;
+  session_summary: string;
+  session_keywords: string[];
+  additional_comments: string | null;
+  created_at: string;
+}
+
+export interface PaymentReceipt {
+  id?: string;
+  email: string;
+  receipt_type: "hgs_membership" | "conference" | string;
+  file_path: string;
+  notes: string | null;
+  created_at: string;
+}
+
+export interface DashboardData {
+  membership: {
+    registrations: MembershipApplication[];
+    receipts: PaymentReceipt[];
+  };
+  conference: {
+    sessions: ThematicSessionSubmission[];
+    abstracts: Abstract[];
+    receipts: PaymentReceipt[];
+  };
+}
+
+export type SectionKey = "membership" | "conference";
+
+export type TabKey =
+  | "membership-registrations"
+  | "membership-receipts"
+  | "conference-sessions"
+  | "conference-abstracts"
+  | "conference-receipts";
+
+export type ExportTableKey =
+  | "membership_applications"
+  | "registrations"
+  | "abstracts"
+  | "thematic_session_submissions_2026"
+  | "payment_receipts_membership"
+  | "payment_receipts_conference";

--- a/src/app/database/layout.tsx
+++ b/src/app/database/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "HGS Database",
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default function DatabaseLayout({ children }: { children: ReactNode }) {
+  return <div className="min-h-screen bg-neutral-50 text-foreground">{children}</div>;
+}

--- a/src/app/database/login/page.tsx
+++ b/src/app/database/login/page.tsx
@@ -1,0 +1,5 @@
+import { LoginForm } from "../_components/LoginForm";
+
+export default function LoginPage() {
+  return <LoginForm />;
+}

--- a/src/app/database/page.tsx
+++ b/src/app/database/page.tsx
@@ -1,0 +1,5 @@
+import { Dashboard } from "./_components/Dashboard";
+
+export default function DatabasePage() {
+  return <Dashboard />;
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/database", "/api/admin"],
+      },
+    ],
+  };
+}

--- a/src/lib/admin-session.ts
+++ b/src/lib/admin-session.ts
@@ -1,0 +1,78 @@
+export const SESSION_COOKIE = "hgs_admin_session";
+export const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+type Payload = { exp: number };
+
+function getSecret(): string {
+  const s = process.env.HGS_ADMIN_SESSION_SECRET;
+  if (!s) throw new Error("Missing HGS_ADMIN_SESSION_SECRET env var");
+  return s;
+}
+
+function b64urlEncode(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(str: string): Uint8Array {
+  const pad = str.length % 4 === 0 ? "" : "=".repeat(4 - (str.length % 4));
+  const s = atob(str.replace(/-/g, "+").replace(/_/g, "/") + pad);
+  const out = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+  return out;
+}
+
+async function hmac(data: string, secret: string): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(data));
+  return new Uint8Array(sig);
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+export async function signSession(ttlSeconds = SESSION_TTL_SECONDS): Promise<string> {
+  const payload: Payload = { exp: Math.floor(Date.now() / 1000) + ttlSeconds };
+  const body = b64urlEncode(new TextEncoder().encode(JSON.stringify(payload)));
+  const sig = await hmac(body, getSecret());
+  return `${body}.${b64urlEncode(sig)}`;
+}
+
+export async function verifySession(cookieValue: string | undefined | null): Promise<boolean> {
+  if (!cookieValue) return false;
+  const parts = cookieValue.split(".");
+  if (parts.length !== 2) return false;
+  const [body, providedSig] = parts;
+  try {
+    const expected = await hmac(body, getSecret());
+    const provided = b64urlDecode(providedSig);
+    if (!timingSafeEqual(expected, provided)) return false;
+    const payload = JSON.parse(new TextDecoder().decode(b64urlDecode(body))) as Payload;
+    if (typeof payload.exp !== "number") return false;
+    return payload.exp * 1000 > Date.now();
+  } catch {
+    return false;
+  }
+}
+
+export function sessionCookieAttributes(): string {
+  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  return `Path=/; HttpOnly; SameSite=Lax${secure}; Max-Age=${SESSION_TTL_SECONDS}`;
+}
+
+export function clearSessionCookieAttributes(): string {
+  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  return `Path=/; HttpOnly; SameSite=Lax${secure}; Max-Age=0`;
+}

--- a/src/lib/supabase-admin.ts
+++ b/src/lib/supabase-admin.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let cachedClient: SupabaseClient | null = null;
+
+export const getSupabaseAdmin = (): SupabaseClient => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. " +
+        "SUPABASE_SERVICE_ROLE_KEY must be set in Vercel project env (server-only).",
+    );
+  }
+
+  if (!cachedClient) {
+    cachedClient = createClient(url, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  return cachedClient;
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { SESSION_COOKIE, verifySession } from "@/lib/admin-session";
+
+function withSecurityHeaders(res: NextResponse): NextResponse {
+  res.headers.set("X-Frame-Options", "DENY");
+  res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  return res;
+}
+
+export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === "/database/login" || pathname === "/api/admin/auth") {
+    return withSecurityHeaders(NextResponse.next());
+  }
+
+  const cookie = request.cookies.get(SESSION_COOKIE)?.value;
+  const valid = await verifySession(cookie);
+
+  if (valid) return withSecurityHeaders(NextResponse.next());
+
+  if (pathname.startsWith("/api/admin")) {
+    return withSecurityHeaders(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = "/database/login";
+  url.search = "";
+  return withSecurityHeaders(NextResponse.redirect(url));
+}
+
+export const config = {
+  matcher: ["/database", "/database/:path*", "/api/admin/:path*"],
+};


### PR DESCRIPTION
## Summary
- New password-gated admin page at `/database` for HGS staff to inspect member applications, conference registrations, abstracts, thematic sessions, and payment receipts.
- Two top-level sections (**HGS Membership** · **Conference 2026**), nested tabs per section, responsive table/card UI with search + sort, row-click detail dialog with signed-URL file downloads.
- Per-table **Excel** export and per-section **ZIP** export (XLSX sheets + all attached receipt files + README).
- Gated by `src/proxy.ts` (Next 16's successor to middleware) on `/database/*` + `/api/admin/*`; HMAC-signed 7-day session cookie; service-role Supabase client is `server-only` and never leaks to the client bundle.

## Before merge — add these to Vercel project env (all three environments)
| Var | Value / source |
|---|---|
| `HGS_ADMIN_PASSWORD` | provided out-of-band |
| `HGS_ADMIN_SESSION_SECRET` | provided out-of-band |
| `SUPABASE_SERVICE_ROLE_KEY` | copy from Supabase → Settings → API → `service_role` |

No DB migration required. No RLS changes. Service role key bypasses RLS, but it is only read server-side.

## Routes added
- `GET /database` — dashboard (auth required)
- `GET /database/login` — password form
- `POST /api/admin/auth` · `DELETE /api/admin/auth` · `GET /api/admin/auth`
- `GET /api/admin/data` — fetch all tables grouped by section
- `POST /api/admin/file-url` — 300 s signed URL for receipt downloads
- `GET /api/admin/export/xlsx?table=…` — one-sheet workbook
- `GET /api/admin/export/zip?section=membership|conference` — streamed ZIP
- `GET /robots.txt` — new; disallows `/database` + `/api/admin`

## Security notes
- `HGS_ADMIN_PASSWORD` check uses constant-time compare with a 500 ms artificial delay on failure.
- Session cookie is `HttpOnly; SameSite=Lax; Secure` (in prod) with HMAC-SHA256 signature over `{exp}`.
- `X-Frame-Options: DENY` and `Referrer-Policy: strict-origin-when-cross-origin` set on all guarded responses.
- Login attempts + file-URL sign requests log IP + UA to Vercel function logs.

## Test plan
- [ ] Set the three env vars in Vercel (Production + Preview).
- [ ] Visit `/database` on a preview deploy → redirects to `/database/login`.
- [ ] Wrong password → 401 + ~500 ms delay + error banner.
- [ ] Correct password → lands on dashboard with Membership section active.
- [ ] Toggle between Membership and Conference 2026 sections — tabs update accordingly.
- [ ] Click a row → detail dialog opens; click Download on an attached file → file opens in a new tab.
- [ ] Click **Export Excel** on each of the 5 tabs → downloads a valid `.xlsx` that opens in Excel.
- [ ] Click **Download ZIP** on both sections → downloads a `.zip` containing XLSX sheets + receipts + `README.txt`.
- [ ] Logout → cookie cleared + redirect to login.
- [ ] Mobile (375 px wide): top bar, pills, tabs, tables-as-cards, and dialog are all usable.
- [ ] `curl -I https://<host>/robots.txt` shows `Disallow: /database`.
- [ ] Grep deployed `_next/static/*.js` bundles for `SUPABASE_SERVICE_ROLE_KEY` and `HGS_ADMIN_PASSWORD` — neither should appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)